### PR TITLE
Fixed duplicate taxels with different indices in certain layouts

### DIFF
--- a/model/tactile_markers.urdf.xacro
+++ b/model/tactile_markers.urdf.xacro
@@ -67,9 +67,13 @@
 		<sensor name="${prefix}thumb_base" update_rate="100" group="proximal">
 			<parent link="${prefix}thumb_proximal_link"/>
 			<tactile channel="${channel}">
-				<xacro:taxel mesh="ptmp2" idx="${tactMap.get('ptop', -1)}"/>
+				<!--pto[p|d] index exists for L2/L3 but is for another taxel -->
+				<xacro:if value="${layout=='L1'}">
+					<xacro:taxel mesh="ptmp2" idx="${tactMap.get('ptop', -1)}"/>
+					<xacro:taxel mesh="ptmd2" idx="${tactMap.get('ptod', -1)}"/>
+				</xacro:if>
+				<!--ptm[p|d] does not exist for L1, so will not be generated except for L2/L3 -->
 				<xacro:taxel mesh="ptmp2" idx="${tactMap.get('ptmp', -1)}"/>
-				<xacro:taxel mesh="ptmd2" idx="${tactMap.get('ptod', -1)}"/>
 				<xacro:taxel mesh="ptmd2" idx="${tactMap.get('ptmd', -1)}"/>
 				<xacro:taxel mesh="ptip2" idx="${tactMap.get('ptip', -1)}"/>
 				<xacro:taxel mesh="ptid2" idx="${tactMap.get('ptid', -1)}"/>
@@ -79,15 +83,20 @@
 		<sensor name="${prefix}palm" update_rate="100" group="palm">
 			<parent link="${prefix}palm_link"/>
 			<tactile channel="${channel}">
+				<!--po does not exist for L2/L3, so will not be generated except for L1 -->
 				<xacro:taxel mesh="pdlo" idx="${tactMap.get('po', -1)}"/>
+				<!--pdlo does not exist for L1, so will not be generated, except for L2/L3 -->
 				<xacro:taxel mesh="pdlo" idx="${tactMap.get('pdlo', -1)}"/>
 				<xacro:taxel mesh="pdl" idx="${tactMap.get('pdl', -1)}"/>
 				<xacro:taxel mesh="pdr" idx="${tactMap.get('pdr', -1)}"/>
 				<xacro:taxel mesh="pdm" idx="${tactMap.get('pdm', -1)}"/>
 				<xacro:taxel mesh="pdi" idx="${tactMap.get('pdi', -1)}"/>
+				<!--pdii does not exist for L1, so will not be generated except for L2/L3 -->
 				<xacro:taxel mesh="pdii" idx="${tactMap.get('pdii', -1)}"/>
 
+				<!--po does not exist for L2/L3, so will not be generated except for L1 -->
 				<xacro:taxel mesh="pco" idx="${tactMap.get('po', -1)}"/>
+				<!--pco does not exist for L1/L3, so will not be generated except for L2 -->
 				<xacro:taxel mesh="pco" idx="${tactMap.get('pco', -1)}"/>
 				<xacro:taxel mesh="pcmp" idx="${tactMap.get('pcmp', -1)}"/>
 				<xacro:taxel mesh="pcmd" idx="${tactMap.get('pcmd', -1)}"/>
@@ -95,13 +104,19 @@
 				<xacro:taxel mesh="pcim" idx="${tactMap.get('pcim', -1)}"/>
 				<xacro:taxel mesh="pcid" idx="${tactMap.get('pcid', -1)}"/>
 
+				<!--po does not exist for L1/L3, so will not be generated except for L2 -->
 				<xacro:taxel mesh="pi" idx="${tactMap.get('pi', -1)}"/>
 
 				<xacro:taxel mesh="ptop" idx="${tactMap.get('ptop', -1)}"/>
 				<xacro:taxel mesh="ptod" idx="${tactMap.get('ptod', -1)}"/>
-				<xacro:taxel mesh="ptmp" idx="${tactMap.get('ptop', -1)}"/>
+				<!--pto[p|d] index exists for L2/L3 but is for another taxel.
+				  It is correct they are used twice for L1 to cover the whole surface of the proximal -->
+				<xacro:if value="${layout=='L1'}">
+					<xacro:taxel mesh="ptmp" idx="${tactMap.get('ptop', -1)}"/>
+					<xacro:taxel mesh="ptmd" idx="${tactMap.get('ptod', -1)}"/>
+				</xacro:if>
+				<!--ptm[p|d] does not exist for L1, so will not be generated except for L2/L3 -->
 				<xacro:taxel mesh="ptmp" idx="${tactMap.get('ptmp', -1)}"/>
-				<xacro:taxel mesh="ptmd" idx="${tactMap.get('ptod', -1)}"/>
 				<xacro:taxel mesh="ptmd" idx="${tactMap.get('ptmd', -1)}"/>
 				<xacro:taxel mesh="ptip" idx="${tactMap.get('ptip', -1)}"/>
 				<xacro:taxel mesh="ptid" idx="${tactMap.get('ptid', -1)}"/>


### PR DESCRIPTION
Fix for #4 
Due to re-using existing meshes for different layouts, some
taxel indices (from taxel.yaml mapping) are used for 2 taxels markers
but no marker can exist twice with different indices.