### PR TITLE
Map L1 taxels once to corresponding L2/L3 meshes

### DIFF
--- a/model/human_hand.urdf.xacro
+++ b/model/human_hand.urdf.xacro
@@ -148,7 +148,7 @@
 			<!-- As we share taxel meshes across all layouts, but L1 doesn't have some taxel indices,
 			     we map L1 taxel indices onto corresponding L2/L3 taxel indices here -->
 			<xacro:if value="${layout == 'L1'}">
-				${mapping.update([(k, mapping.get(v,-1)) for k, v in [('tmm', 'tmo'), ('ptmp', 'ptop'), ('ptmd', 'ptod')]])}
+				<xacro:if value="${mapping.update([(k, mapping.get(v,-1)) for k, v in [('tmm', 'tmo'), ('ptmp', 'ptop'), ('ptmd', 'ptod')]])}" />
 			</xacro:if>
 			<xacro:property name="taxeldata_file" value="${mapping.get('taxeldata_file',package + '/model/'+layout+side+'.yaml')}"/>
 			<!-- load taxeldata dictionary (positions + orientations) of taxel normals from file if available, else None -->

--- a/model/human_hand.urdf.xacro
+++ b/model/human_hand.urdf.xacro
@@ -145,6 +145,11 @@
 				<xacro:property name="side" value="${mapping.get('handedness','right')}"/>
 			</xacro:if>
 			<xacro:property name="layout" value="${mapping['layout']}"/>
+			<!-- As we share taxel meshes across all layouts, but L1 doesn't have some taxel indices,
+			     we map L1 taxel indices onto corresponding L2/L3 taxel indices here -->
+			<xacro:if value="${layout == 'L1'}">
+				${mapping.update([(k, mapping.get(v,-1)) for k, v in [('tmm', 'tmo'), ('ptmp', 'ptop'), ('ptmd', 'ptod')]])}
+			</xacro:if>
 			<xacro:property name="taxeldata_file" value="${mapping.get('taxeldata_file',package + '/model/'+layout+side+'.yaml')}"/>
 			<!-- load taxeldata dictionary (positions + orientations) of taxel normals from file if available, else None -->
 			<xacro:property name="taxel_data" value="${None}"/>

--- a/model/tactile_markers.urdf.xacro
+++ b/model/tactile_markers.urdf.xacro
@@ -67,12 +67,6 @@
 		<sensor name="${prefix}thumb_base" update_rate="100" group="proximal">
 			<parent link="${prefix}thumb_proximal_link"/>
 			<tactile channel="${channel}">
-				<!--pto[p|d] index exists for L2/L3 but is for another taxel -->
-				<xacro:if value="${layout=='L1'}">
-					<xacro:taxel mesh="ptmp2" idx="${tactMap.get('ptop', -1)}"/>
-					<xacro:taxel mesh="ptmd2" idx="${tactMap.get('ptod', -1)}"/>
-				</xacro:if>
-				<!--ptm[p|d] does not exist for L1, so will not be generated except for L2/L3 -->
 				<xacro:taxel mesh="ptmp2" idx="${tactMap.get('ptmp', -1)}"/>
 				<xacro:taxel mesh="ptmd2" idx="${tactMap.get('ptmd', -1)}"/>
 				<xacro:taxel mesh="ptip2" idx="${tactMap.get('ptip', -1)}"/>
@@ -109,13 +103,6 @@
 
 				<xacro:taxel mesh="ptop" idx="${tactMap.get('ptop', -1)}"/>
 				<xacro:taxel mesh="ptod" idx="${tactMap.get('ptod', -1)}"/>
-				<!--pto[p|d] index exists for L2/L3 but is for another taxel.
-				  It is correct they are used twice for L1 to cover the whole surface of the proximal -->
-				<xacro:if value="${layout=='L1'}">
-					<xacro:taxel mesh="ptmp" idx="${tactMap.get('ptop', -1)}"/>
-					<xacro:taxel mesh="ptmd" idx="${tactMap.get('ptod', -1)}"/>
-				</xacro:if>
-				<!--ptm[p|d] does not exist for L1, so will not be generated except for L2/L3 -->
 				<xacro:taxel mesh="ptmp" idx="${tactMap.get('ptmp', -1)}"/>
 				<xacro:taxel mesh="ptmd" idx="${tactMap.get('ptmd', -1)}"/>
 				<xacro:taxel mesh="ptip" idx="${tactMap.get('ptip', -1)}"/>


### PR DESCRIPTION
I found another approach to map L1 indices onto additional taxel meshes. This approach avoids conditionals spread all over the xacro file and collects all relevant changes in a single place.