### PR TITLE
Added urdf_tactile as an exec dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>urdf_tactile</exec_depend>
 
   <export>
   </export>


### PR DESCRIPTION
since human_hand_description relies on `<tactile>` elements in URDF, I believe one should add `urdf_tactile` as an `exec_depend`