### PR TITLE
F#13 map prop files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Human Hand Model
 
 This package is derived from the [pisa_hand_description](https://github.com/WEARHAP/hand-models/tree/master/pisa_hand_description) package
 
+## Usage 
+
 The hand URDF model is loaded and displayed with this launch command
 
 ```
@@ -10,17 +12,46 @@ roslaunch human_hand_description display.launch tactile_mapping:=<mapping>
 ```
 
 mandatory arguments:
+
 - tactile_mapping: P3r | P3l | P2 | P1
 
 optional arguments:
+
 - robot_name: human_hand
 - use_synergy: true | false
+- scale: 1.0 (default)
+- calibrated: true | false
+- side: '' (read from taxel.yaml)| 'left' |'right' 
 
-authors:
+## Advanced Usage
+
+Directly upload the human_hand_description with the file `upload.launch`
+
+mandatory arguments:
+
+- tactile_mapping: P3r | P3l | P2 | P1 (see taxel.yaml)
+
+optional arguments:
+
+- use_synergy: true | false
+- scale: 1.0 (default)
+- calibrated: true | false
+- side: '' (=read from taxel.yaml)| 'left' |'right' 
+- gui: true | false
+- jsp: true | false
+- tactile_channel: "tactile glove" (default)
+- prefix: "" (default)
+- property_file: "" (default= found in human_hand_description package)
+- mapping_file: "" (default= found in human_hand_description package)
+
+
+## Acknowledgment
+
+### authors:
 - Guillaume Walck gwalck@techfak.uni-bielefeld.de
 - Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
-original authors (Pisa):
+### original authors (Pisa):
 - r.nuti@hotmail.it
 - carlos@beta-robots.com
 - matteo.bianchi@centropiaggio.unipi.it

--- a/launch/upload.launch
+++ b/launch/upload.launch
@@ -7,6 +7,8 @@
 	<!-- use synergy with kinematics-based <mimic> tag -->
 	<arg name="use_synergy" default="true"/>
 	<arg name="tactile_mapping"/>
+	<arg name="mapping_file" default=""/>
+	<arg name="property_file" default=""/>
 	<arg name="tactile_channel" default="tactile glove"/>
 	<arg name="prefix" default=""/>
 	<arg name="scale" default="1.0"/>
@@ -14,8 +16,8 @@
 
 	<!-- load robot description -->
 	<arg name="__noetic" value="$(eval env('ROS_PYTHON_VERSION') == '3')" />
-	<param name="robot_description" if="$(arg __noetic)" command="xacro $(find human_hand_description)/robots/human_hand.urdf.xacro use_synergy:=$(arg use_synergy) tactile_mapping:=$(arg tactile_mapping) tactile_channel:='$(arg tactile_channel)' prefix:=$(arg prefix) scale:=$(arg scale) side:=$(arg side)" />
-	<param name="robot_description" unless="$(arg __noetic)" command="xacro --xacro-ns $(find human_hand_description)/robots/human_hand.urdf.xacro use_synergy:=$(arg use_synergy) tactile_mapping:=$(arg tactile_mapping) tactile_channel:='$(arg tactile_channel)' prefix:=$(arg prefix) scale:=$(arg scale) side:=$(arg side)" />
+	<param name="robot_description" if="$(arg __noetic)" command="xacro $(find human_hand_description)/robots/human_hand.urdf.xacro use_synergy:=$(arg use_synergy) property_file:=$(arg property_file) mapping_file:=$(arg mapping_file) tactile_mapping:=$(arg tactile_mapping) tactile_channel:='$(arg tactile_channel)' prefix:=$(arg prefix) scale:=$(arg scale) side:=$(arg side)" />
+	<param name="robot_description" unless="$(arg __noetic)" command="xacro --xacro-ns $(find human_hand_description)/robots/human_hand.urdf.xacro use_synergy:=$(arg use_synergy) property_file:=$(arg property_file) mapping_file:=$(arg mapping_file) tactile_mapping:=$(arg tactile_mapping) tactile_channel:='$(arg tactile_channel)' prefix:=$(arg prefix) scale:=$(arg scale) side:=$(arg side)" />
 
 	<group if="$(arg jsp)">
 		<arg name="__jsp" value="joint_state_publisher" unless="$(arg gui)"/>

--- a/model/human_hand.urdf.xacro
+++ b/model/human_hand.urdf.xacro
@@ -129,17 +129,29 @@
 	<!-- HUMAN HAND MODEL -->
 	<xacro:macro name="human_hand"
 	             params="parent link_prefix:=^|'' joint_prefix:=^|'' scale:=1.0
-	                     use_synergy side:='' tactile_mapping:='' tactile_channel:='tactile glove' *origin">
-		<!-- load kinematics properties -->
+	                     use_synergy side:='' property_file:=^|'' mapping_file:=^|'' tactile_mapping:=''
+	                     tactile_channel:='tactile glove' *origin">
 		<xacro:property name="package" value="$(find human_hand_description)"/>
-		<xacro:property name="properties" value="${xacro.load_yaml(package + '/model/properties.yaml')}" />
+		<!-- load kinematics properties from file if given or from default file -->
+		<xacro:if value="${property_file in ['', '-']}">
+			<xacro:property name="properties" value="${xacro.load_yaml(package + '/model/properties.yaml')}" />
+		</xacro:if>
+		<xacro:unless value="${property_file in ['', '-']}">
+			<xacro:property name="properties" value="${xacro.load_yaml(property_file)}" />
+		</xacro:unless>
+		<!-- load or read other properties -->
 		<xacro:property name="synergies" value="${properties['synergies']}"/>
 		<xacro:property name="scale_factor" value="${scale}"/>
 
-		<!-- load taxel mapping -->
+		<!-- if desired, load taxel mapping from file if given or from default file -->
 		<xacro:property name="mapping" value="${None}"/>
 		<xacro:if value="${tactile_mapping not in ['', '-']}">
-			<xacro:property name="mapping" value="${xacro.load_yaml(package + '/model/taxel.yaml')[tactile_mapping]}" />
+			<xacro:if value="${mapping_file in ['', '-']}">
+				<xacro:property name="mapping" value="${xacro.load_yaml(package + '/model/taxel.yaml')[tactile_mapping]}"/>
+			</xacro:if>
+			<xacro:unless value="${mapping_file in ['', '-']}">
+				<xacro:property name="mapping" value="${xacro.load_yaml(mapping_file)[tactile_mapping]}" />
+			</xacro:unless>
 			<!-- if side is not yet specified, try to fetch it from the tactile_mapping dictionary -->
 			<xacro:if value="${side not in ['left', 'right']}">
 				<xacro:property name="side" value="${mapping.get('handedness','right')}"/>

--- a/robots/human_hand.urdf.xacro
+++ b/robots/human_hand.urdf.xacro
@@ -12,6 +12,8 @@
 	<xacro:arg name="use_synergy" default="false"/>
 	<xacro:arg name="tactile_mapping" default=""/>
 	<xacro:arg name="tactile_channel" default="tactile glove"/>
+	<xacro:arg name="mapping_file" default=""/>
+	<xacro:arg name="property_file" default=""/>
 
 	<xacro:include filename="../model/human_hand.urdf.xacro"/>
 
@@ -22,7 +24,9 @@
 	                  scale="$(arg scale)"
 	                  side="$(arg side)" use_synergy="$(arg use_synergy)"
 	                  tactile_mapping="$(arg tactile_mapping)"
-	                  tactile_channel="'$(arg tactile_channel)'">
+	                  tactile_channel="'$(arg tactile_channel)'"
+	                  mapping_file="$(arg mapping_file)"
+	                  property_file="$(arg property_file)">
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 	</xacro:human_hand>
 


### PR DESCRIPTION
Solves #13 
Since `display.launch` was already hiding some arguments of `upload.launch` I also did not add the new arguments to `display.launch` only to `upload.launch`.
Also passing the path to layout files was not added at all as these settings are completely linked to the meshes that will remain part of the package at the contrary of mappings and sizing that depend on outside devices/settings.

This was tested in my own usage of `upload.launch` passing my own files and directly with `display.launch` which then used default settings.